### PR TITLE
feat(eslint-config)!: remove globals dep and refactor config API

### DIFF
--- a/eng/eslint.config.js
+++ b/eng/eslint.config.js
@@ -1,9 +1,13 @@
 import { defineTypescriptConfig } from "@camaro/eslint-config/typescript";
+import globals from "globals";
 
 export default defineTypescriptConfig(
+    {},
     {
         files: ["**/*.ts"],
-        globals: ["node"],
+        languageOptions: {
+            globals: globals.node,
+        },
     },
     {
         ignores: ["packages/**/lib/**/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@commitlint/cli": "^20.4.3",
         "@commitlint/config-conventional": "^20.4.3",
         "cspell": "^9.7.0",
+        "globals": "^17.4.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.2"
       }
@@ -3234,6 +3235,7 @@
       "version": "17.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
       "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4522,13 +4524,12 @@
     },
     "packages/eslint-config": {
       "name": "@camaro/eslint-config",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "eslint-plugin-simple-import-sort": "^12.1.1",
-        "globals": "^17.4.0"
+        "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "devDependencies": {
         "eslint": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",
     "cspell": "^9.7.0",
+    "globals": "^17.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2"
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@eslint/js": "^10.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "globals": "^17.4.0"
+    "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "devDependencies": {
     "eslint": "^10.0.3",

--- a/packages/eslint-config/src/common.ts
+++ b/packages/eslint-config/src/common.ts
@@ -1,9 +1,8 @@
-import { type ConfigWithExtendsArray } from "@eslint/config-helpers";
+import { type ConfigWithExtendsArray, type ExtendsElement } from "@eslint/config-helpers";
 import eslintJS from "@eslint/js";
 import stylistic, { type StylisticCustomizeOptions } from "@stylistic/eslint-plugin";
 import { type Config, defineConfig } from "eslint/config";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
-import globals from "globals";
 
 const defaultStylisticOptions: StylisticCustomizeOptions = {
     indent: 4,
@@ -12,24 +11,12 @@ const defaultStylisticOptions: StylisticCustomizeOptions = {
     jsx: false,
 };
 
-export type GlobalCategory = keyof typeof globals;
-
 export interface CommonOptions extends StylisticCustomizeOptions {
-    globals?: GlobalCategory[];
+    extends?: ExtendsElement;
 }
 
-export const resolveGlobals = (globalCategories: GlobalCategory[] = []): Record<string, boolean> => {
-    const resolvedGlobals: Record<string, boolean> = {};
-
-    for (const category of globalCategories) {
-        Object.assign(resolvedGlobals, globals[category]);
-    }
-
-    return resolvedGlobals;
-};
-
 export const defineCommonConfig = (options: CommonOptions = {}, ...configs: ConfigWithExtendsArray): Config[] => {
-    const { globals: globalCategories = [], ...stylisticOptions } = options;
+    const { ...stylisticOptions } = options;
     const styleLintConfig = stylistic.configs.customize({
         ...defaultStylisticOptions,
         ...stylisticOptions,
@@ -41,11 +28,6 @@ export const defineCommonConfig = (options: CommonOptions = {}, ...configs: Conf
         {
             plugins: {
                 "simple-import-sort": simpleImportSort,
-            },
-        },
-        {
-            languageOptions: {
-                globals: resolveGlobals(globalCategories),
             },
             rules: {
                 "eqeqeq": "error",

--- a/packages/eslint-config/src/typescript.ts
+++ b/packages/eslint-config/src/typescript.ts
@@ -2,23 +2,21 @@ import { type ConfigWithExtendsArray } from "@eslint/config-helpers";
 import { type Config, defineConfig } from "eslint/config";
 import eslintTS from "typescript-eslint";
 
-import { type CommonOptions, defineCommonConfig, resolveGlobals } from "./common.ts";
+import { type CommonOptions, defineCommonConfig } from "./common.ts";
 
-export interface TypescriptOptions extends CommonOptions {
-    files?: string[];
-}
+export type TypescriptOptions = CommonOptions;
 
 export const defineTypescriptConfig = (
     options: TypescriptOptions = {},
     ...configs: ConfigWithExtendsArray
 ): Config[] => {
-    const { files, ...commonOptions } = options;
+    const { ...commonOptions } = options;
     const common = defineCommonConfig(commonOptions);
 
     return defineConfig(
         common,
         {
-            files,
+            files: ["**/*.{ts,tsx,mts,cts}"],
             extends: [
                 eslintTS.configs.recommendedTypeChecked,
                 eslintTS.configs.strictTypeChecked,
@@ -27,7 +25,6 @@ export const defineTypescriptConfig = (
             languageOptions: {
                 parser: eslintTS.parser,
                 parserOptions: { projectService: true },
-                globals: resolveGlobals(options.globals),
             },
             rules: {
                 "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],

--- a/packages/eslint-config/test/util.ts
+++ b/packages/eslint-config/test/util.ts
@@ -7,7 +7,7 @@ import { defineTypescriptConfig } from "../src/typescript.js";
 
 const eslint = new ESLint({
     overrideConfigFile: true,
-    baseConfig: defineTypescriptConfig({ files: ["**/*.ts"] }) as Linter.Config,
+    baseConfig: defineTypescriptConfig() as Linter.Config,
 });
 
 const dummyFilePath = path.resolve(import.meta.dirname, "dummy.ts");


### PR DESCRIPTION
BREAKING CHANGE: globals and files options removed from config API, consumers need to handle globals and file matching directly via ESLint languageOptions